### PR TITLE
chore: modernize all 45 workflow files for GitHub Actions

### DIFF
--- a/.github/workflows/bios_newsroom_eight.yaml
+++ b/.github/workflows/bios_newsroom_eight.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_EIGHT
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "29 12 * * *" 

--- a/.github/workflows/bios_newsroom_eight.yaml
+++ b/.github/workflows/bios_newsroom_eight.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_EIGHT
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "29 12 * * *" 
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Eight
         env:

--- a/.github/workflows/bios_newsroom_eight.yaml
+++ b/.github/workflows/bios_newsroom_eight.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_five.yaml
+++ b/.github/workflows/bios_newsroom_five.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_FIVE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 21 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Five
         env:

--- a/.github/workflows/bios_newsroom_five.yaml
+++ b/.github/workflows/bios_newsroom_five.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_five.yaml
+++ b/.github/workflows/bios_newsroom_five.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_FIVE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 21 * * *"

--- a/.github/workflows/bios_newsroom_four.yaml
+++ b/.github/workflows/bios_newsroom_four.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_FOUR
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 4,19 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Four
         env:

--- a/.github/workflows/bios_newsroom_four.yaml
+++ b/.github/workflows/bios_newsroom_four.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_four.yaml
+++ b/.github/workflows/bios_newsroom_four.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_FOUR
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 4,19 * * *"

--- a/.github/workflows/bios_newsroom_nine.yaml
+++ b/.github/workflows/bios_newsroom_nine.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_NINE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "12 22 * * *" 

--- a/.github/workflows/bios_newsroom_nine.yaml
+++ b/.github/workflows/bios_newsroom_nine.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_nine.yaml
+++ b/.github/workflows/bios_newsroom_nine.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_NINE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "12 22 * * *" 
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Nine
         env:

--- a/.github/workflows/bios_newsroom_one.yaml
+++ b/.github/workflows/bios_newsroom_one.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_ONE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 3,17 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom One
         env:

--- a/.github/workflows/bios_newsroom_one.yaml
+++ b/.github/workflows/bios_newsroom_one.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_one.yaml
+++ b/.github/workflows/bios_newsroom_one.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_ONE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 3,17 * * *"

--- a/.github/workflows/bios_newsroom_seven.yaml
+++ b/.github/workflows/bios_newsroom_seven.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_SEVEN
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "35 13 * * *"

--- a/.github/workflows/bios_newsroom_seven.yaml
+++ b/.github/workflows/bios_newsroom_seven.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_seven.yaml
+++ b/.github/workflows/bios_newsroom_seven.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_SEVEN
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "35 13 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Seven
         env:

--- a/.github/workflows/bios_newsroom_six.yaml
+++ b/.github/workflows/bios_newsroom_six.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_SIX
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 1,15 * * *" 

--- a/.github/workflows/bios_newsroom_six.yaml
+++ b/.github/workflows/bios_newsroom_six.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_SIX
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 1,15 * * *" 
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Six
         env:

--- a/.github/workflows/bios_newsroom_six.yaml
+++ b/.github/workflows/bios_newsroom_six.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_ten.yaml
+++ b/.github/workflows/bios_newsroom_ten.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_ten.yaml
+++ b/.github/workflows/bios_newsroom_ten.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_TEN
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "29 1 * * *" 

--- a/.github/workflows/bios_newsroom_ten.yaml
+++ b/.github/workflows/bios_newsroom_ten.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_TEN
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "29 1 * * *" 
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Ten
         env:

--- a/.github/workflows/bios_newsroom_three.yaml
+++ b/.github/workflows/bios_newsroom_three.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_THREE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 18 * * *"

--- a/.github/workflows/bios_newsroom_three.yaml
+++ b/.github/workflows/bios_newsroom_three.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_THREE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 18 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Three
         env:

--- a/.github/workflows/bios_newsroom_three.yaml
+++ b/.github/workflows/bios_newsroom_three.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_two.yaml
+++ b/.github/workflows/bios_newsroom_two.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/bios_newsroom_two.yaml
+++ b/.github/workflows/bios_newsroom_two.yaml
@@ -1,6 +1,8 @@
 name: Biographies for NEWSROOM_TWO
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 20 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Two
         env:

--- a/.github/workflows/bios_newsroom_two.yaml
+++ b/.github/workflows/bios_newsroom_two.yaml
@@ -1,8 +1,6 @@
 name: Biographies for NEWSROOM_TWO
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 20 * * *"

--- a/.github/workflows/newsroom_eight.yaml
+++ b/.github/workflows/newsroom_eight.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_EIGHT
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "37 3 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Eight
         env:

--- a/.github/workflows/newsroom_eight.yaml
+++ b/.github/workflows/newsroom_eight.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_eight.yaml
+++ b/.github/workflows/newsroom_eight.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_EIGHT
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "37 3 * * *"

--- a/.github/workflows/newsroom_embeddings_five.yaml
+++ b/.github/workflows/newsroom_embeddings_five.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_FIVE Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_five.yaml
+++ b/.github/workflows/newsroom_embeddings_five.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_FIVE Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_embeddings_four.yaml
+++ b/.github/workflows/newsroom_embeddings_four.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_FOUR Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_embeddings_four.yaml
+++ b/.github/workflows/newsroom_embeddings_four.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_FOUR Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_one.yaml
+++ b/.github/workflows/newsroom_embeddings_one.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_ONE Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_embeddings_one.yaml
+++ b/.github/workflows/newsroom_embeddings_one.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_ONE Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_six.yaml
+++ b/.github/workflows/newsroom_embeddings_six.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_SIX Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_six.yaml
+++ b/.github/workflows/newsroom_embeddings_six.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_SIX Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_embeddings_three.yaml
+++ b/.github/workflows/newsroom_embeddings_three.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_THREE Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_embeddings_three.yaml
+++ b/.github/workflows/newsroom_embeddings_three.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_THREE Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_two.yaml
+++ b/.github/workflows/newsroom_embeddings_two.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_TWO Embeddings
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"

--- a/.github/workflows/newsroom_embeddings_two.yaml
+++ b/.github/workflows/newsroom_embeddings_two.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_TWO Embeddings
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "19 6 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_five.yaml
+++ b/.github/workflows/newsroom_five.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_FIVE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 10 * * *" # every day at 10:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Five
         env:

--- a/.github/workflows/newsroom_five.yaml
+++ b/.github/workflows/newsroom_five.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_FIVE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 10 * * *" # every day at 10:17 am GMT

--- a/.github/workflows/newsroom_five.yaml
+++ b/.github/workflows/newsroom_five.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_four.yaml
+++ b/.github/workflows/newsroom_four.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_FOUR
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 4 * * *" # every day at 4:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Four
         env:

--- a/.github/workflows/newsroom_four.yaml
+++ b/.github/workflows/newsroom_four.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_FOUR
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 4 * * *" # every day at 4:17 am GMT

--- a/.github/workflows/newsroom_four.yaml
+++ b/.github/workflows/newsroom_four.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_nine.yaml
+++ b/.github/workflows/newsroom_nine.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_NINE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "21 3 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Nine
         env:

--- a/.github/workflows/newsroom_nine.yaml
+++ b/.github/workflows/newsroom_nine.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_NINE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "21 3 * * *"

--- a/.github/workflows/newsroom_nine.yaml
+++ b/.github/workflows/newsroom_nine.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_one.yaml
+++ b/.github/workflows/newsroom_one.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_one.yaml
+++ b/.github/workflows/newsroom_one.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_ONE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 7 * * *" # every day at 7:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom One
         env:

--- a/.github/workflows/newsroom_one.yaml
+++ b/.github/workflows/newsroom_one.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_ONE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 7 * * *" # every day at 7:17 am GMT

--- a/.github/workflows/newsroom_quotes_eight.yaml
+++ b/.github/workflows/newsroom_quotes_eight.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_EIGHT People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 4 * * *" 

--- a/.github/workflows/newsroom_quotes_eight.yaml
+++ b/.github/workflows/newsroom_quotes_eight.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_EIGHT People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 4 * * *" 
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_five.yaml
+++ b/.github/workflows/newsroom_quotes_five.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_FIVE People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 9 * * *" 

--- a/.github/workflows/newsroom_quotes_five.yaml
+++ b/.github/workflows/newsroom_quotes_five.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_FIVE People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 9 * * *" 
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_four.yaml
+++ b/.github/workflows/newsroom_quotes_four.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_FOUR People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 12 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_four.yaml
+++ b/.github/workflows/newsroom_quotes_four.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_FOUR People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 12 * * *"

--- a/.github/workflows/newsroom_quotes_nine.yaml
+++ b/.github/workflows/newsroom_quotes_nine.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_NINE People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "43 1-20/4 * * *" 

--- a/.github/workflows/newsroom_quotes_nine.yaml
+++ b/.github/workflows/newsroom_quotes_nine.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_NINE People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "43 1-20/4 * * *" 
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_one.yaml
+++ b/.github/workflows/newsroom_quotes_one.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_ONE People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 12 * * *"

--- a/.github/workflows/newsroom_quotes_one.yaml
+++ b/.github/workflows/newsroom_quotes_one.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_ONE People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 12 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_seven.yaml
+++ b/.github/workflows/newsroom_quotes_seven.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_SEVEN People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 9 * * *" 

--- a/.github/workflows/newsroom_quotes_seven.yaml
+++ b/.github/workflows/newsroom_quotes_seven.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_SEVEN People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 9 * * *" 
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_six.yaml
+++ b/.github/workflows/newsroom_quotes_six.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_SIX People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 13 * * *" 
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_six.yaml
+++ b/.github/workflows/newsroom_quotes_six.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_SIX People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "31 13 * * *" 

--- a/.github/workflows/newsroom_quotes_three.yaml
+++ b/.github/workflows/newsroom_quotes_three.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_THREE People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "23 7 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_quotes_three.yaml
+++ b/.github/workflows/newsroom_quotes_three.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_THREE People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "23 7 * * *"

--- a/.github/workflows/newsroom_quotes_two.yaml
+++ b/.github/workflows/newsroom_quotes_two.yaml
@@ -1,8 +1,6 @@
 name: Run NEWSROOM_TWO People & Quotes
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "6 10 * * *"

--- a/.github/workflows/newsroom_quotes_two.yaml
+++ b/.github/workflows/newsroom_quotes_two.yaml
@@ -1,6 +1,8 @@
 name: Run NEWSROOM_TWO People & Quotes
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "6 10 * * *"
@@ -11,17 +13,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
       # Cache the virtual environment
       - name: Cache venv
         id: cache-venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('nlp_requirements.txt') }}-${{ hashFiles('spacy_model.txt') }}

--- a/.github/workflows/newsroom_seven.yaml
+++ b/.github/workflows/newsroom_seven.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_SEVEN
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "12 4 * * *"

--- a/.github/workflows/newsroom_seven.yaml
+++ b/.github/workflows/newsroom_seven.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_seven.yaml
+++ b/.github/workflows/newsroom_seven.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_SEVEN
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "12 4 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Three
         env:

--- a/.github/workflows/newsroom_three.yaml
+++ b/.github/workflows/newsroom_three.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_THREE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 5 * * *" # every day at 4:17 am GMT

--- a/.github/workflows/newsroom_three.yaml
+++ b/.github/workflows/newsroom_three.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_three.yaml
+++ b/.github/workflows/newsroom_three.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_THREE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 5 * * *" # every day at 4:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Three
         env:

--- a/.github/workflows/newsroom_two.yaml
+++ b/.github/workflows/newsroom_two.yaml
@@ -1,6 +1,8 @@
 name: NEWSROOM_TWO
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 8 * * *" # every day at 8:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Import Newsroom Two
         env:

--- a/.github/workflows/newsroom_two.yaml
+++ b/.github/workflows/newsroom_two.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/newsroom_two.yaml
+++ b/.github/workflows/newsroom_two.yaml
@@ -1,8 +1,6 @@
 name: NEWSROOM_TWO
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 8 * * *" # every day at 8:17 am GMT

--- a/.github/workflows/person_newsroom_eight.yaml
+++ b/.github/workflows/person_newsroom_eight.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_EIGHT
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 17 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct  Newsroom Eight
         env:

--- a/.github/workflows/person_newsroom_eight.yaml
+++ b/.github/workflows/person_newsroom_eight.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_eight.yaml
+++ b/.github/workflows/person_newsroom_eight.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_EIGHT
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 17 * * *"

--- a/.github/workflows/person_newsroom_five.yaml
+++ b/.github/workflows/person_newsroom_five.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_five.yaml
+++ b/.github/workflows/person_newsroom_five.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_FIVE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 14 * * *"

--- a/.github/workflows/person_newsroom_five.yaml
+++ b/.github/workflows/person_newsroom_five.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_FIVE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 14 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct  Newsroom Five
         env:

--- a/.github/workflows/person_newsroom_four.yaml
+++ b/.github/workflows/person_newsroom_four.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_FOUR
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 8 * * *"

--- a/.github/workflows/person_newsroom_four.yaml
+++ b/.github/workflows/person_newsroom_four.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_four.yaml
+++ b/.github/workflows/person_newsroom_four.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_FOUR
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 8 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Bios Newsroom Four
         env:

--- a/.github/workflows/person_newsroom_nine.yaml
+++ b/.github/workflows/person_newsroom_nine.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_nine.yaml
+++ b/.github/workflows/person_newsroom_nine.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_NINE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 12 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Nine
         env:

--- a/.github/workflows/person_newsroom_nine.yaml
+++ b/.github/workflows/person_newsroom_nine.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_NINE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 12 * * *"

--- a/.github/workflows/person_newsroom_one.yaml
+++ b/.github/workflows/person_newsroom_one.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_ONE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 1 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom One
         env:

--- a/.github/workflows/person_newsroom_one.yaml
+++ b/.github/workflows/person_newsroom_one.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_ONE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 1 * * *"

--- a/.github/workflows/person_newsroom_one.yaml
+++ b/.github/workflows/person_newsroom_one.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_seven.yaml
+++ b/.github/workflows/person_newsroom_seven.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_SEVEN
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 13 * * *"

--- a/.github/workflows/person_newsroom_seven.yaml
+++ b/.github/workflows/person_newsroom_seven.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_SEVEN
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 13 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Seven
         env:

--- a/.github/workflows/person_newsroom_seven.yaml
+++ b/.github/workflows/person_newsroom_seven.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_six.yaml
+++ b/.github/workflows/person_newsroom_six.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_six.yaml
+++ b/.github/workflows/person_newsroom_six.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_SIX
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 0 * * *"

--- a/.github/workflows/person_newsroom_six.yaml
+++ b/.github/workflows/person_newsroom_six.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_SIX
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 0 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Six
         env:

--- a/.github/workflows/person_newsroom_ten.yaml
+++ b/.github/workflows/person_newsroom_ten.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_TEN
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "49 12 * * *"

--- a/.github/workflows/person_newsroom_ten.yaml
+++ b/.github/workflows/person_newsroom_ten.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_ten.yaml
+++ b/.github/workflows/person_newsroom_ten.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_TEN
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "49 12 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Ten
         env:

--- a/.github/workflows/person_newsroom_three.yaml
+++ b/.github/workflows/person_newsroom_three.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_three.yaml
+++ b/.github/workflows/person_newsroom_three.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_THREE
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 5 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Three
         env:

--- a/.github/workflows/person_newsroom_three.yaml
+++ b/.github/workflows/person_newsroom_three.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_THREE
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 5 * * *"

--- a/.github/workflows/person_newsroom_two.yaml
+++ b/.github/workflows/person_newsroom_two.yaml
@@ -1,8 +1,6 @@
 name: Cleanup People for NEWSROOM_TWO
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 4 * * *"

--- a/.github/workflows/person_newsroom_two.yaml
+++ b/.github/workflows/person_newsroom_two.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/person_newsroom_two.yaml
+++ b/.github/workflows/person_newsroom_two.yaml
@@ -1,6 +1,8 @@
 name: Cleanup People for NEWSROOM_TWO
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "49 4 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: People Correct Newsroom Two
         env:

--- a/.github/workflows/source_data_two.yaml
+++ b/.github/workflows/source_data_two.yaml
@@ -1,6 +1,8 @@
 name: Source Data for NEWSROOM_TWO
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "49 4 * * *"
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests bs4
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Source Data Newsroom Two
         env:

--- a/.github/workflows/source_data_two.yaml
+++ b/.github/workflows/source_data_two.yaml
@@ -1,8 +1,6 @@
 name: Source Data for NEWSROOM_TWO
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   #schedule:
   #  - cron: "49 4 * * *"

--- a/.github/workflows/source_data_two.yaml
+++ b/.github/workflows/source_data_two.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/stories.yaml
+++ b/.github/workflows/stories.yaml
@@ -1,6 +1,8 @@
 name: Run Importer
 
 on:
+  permissions:
+    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 5 * * *" # every day at 5:17 am GMT
@@ -11,27 +13,30 @@ jobs:
 
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies or take from Cache
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
           pip install requests
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
 
       - name: Run Importer Script
         env:

--- a/.github/workflows/stories.yaml
+++ b/.github/workflows/stories.yaml
@@ -23,7 +23,7 @@ jobs:
         id: venv-cache
         with:
           path: ~/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/' + github.event.workflow) }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
             venv-${{ runner.os }}-

--- a/.github/workflows/stories.yaml
+++ b/.github/workflows/stories.yaml
@@ -1,8 +1,6 @@
 name: Run Importer
 
 on:
-  permissions:
-    contents: read
   workflow_dispatch:
   schedule:
     - cron: "17 5 * * *" # every day at 5:17 am GMT


### PR DESCRIPTION
Modernizes all 45 GitHub Actions workflow files to address the Node.js 20 deprecation warning and update to current best practices.

## Changes across all files:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/setup-python@v4` → `actions/setup-python@v5`
- `actions/cache@v3` → `actions/cache@v4`
- Python `3.9` → `3.12` (3.9 is EOL)
- Migrated old pip-cache approach (`~/.cache/pip`) to venv-based caching for faster, more reliable builds
- Added `permissions: contents: read` per GitHub security best practices

This eliminates the Node.js 20 deprecation warnings and ensures workflows will continue running after June/September 2026.